### PR TITLE
ARTEMIS-2705 Use Docker aarch64 image to build a native library

### DIFF
--- a/scripts/aarch64test.sh
+++ b/scripts/aarch64test.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# This will generate a 32bit image for testing and start the shell
+
+docker build -f src/main/docker/Dockerfile-centos.aarch64 -t artemis-native-builder:aarch64 .
+
+# This is mapping your maven repository inside the image to avoid you downloading the internet again
+docker run -it --rm -v $PWD/target/lib:/work/target/lib -v $HOME/.m2/repository/:/root/.m2/repository artemis-native-builder:aarch64 ./mvnw test
+
+# you could use it this way
+#docker build -f src/main/docker/Dockerfile-centos -t artemis-native-builder . && docker run -it --rm -v $PWD/target/lib:/work/target/lib -v $HOME/.m2/repository/:/root/.m2/repository artemis-native-builder bash

--- a/scripts/compile-using-docker.sh
+++ b/scripts/compile-using-docker.sh
@@ -22,6 +22,14 @@ docker run --rm -v $PWD/target/lib:/work/target/lib artemis-native-builder "$@"
 chown -Rv $USER:$GID ./bin
 ls -liat ./target/lib
 
+echo -e "\nGoing to build libartemis-native.so for aarch64"
+# enable QEMU to be able to run non-x86_64 Docker images
+docker run -it --rm --privileged multiarch/qemu-user-static --reset --credential yes --persistent yes
+docker build -f src/main/docker/Dockerfile-centos.aarch64 -t artemis-native-builder:aarch64 .
+docker run --rm -v $PWD/target/lib:/work/target/lib artemis-native-builder:aarch64 "$@"
+ls -liat ./target/lib
+
+
 # Note: You may need to authorize docker to map folder at your folder structure
 #docker build -f src/main/docker/Dockerfile-centos -t artemis-native-builder . && docker run -it --rm -v $PWD/target/lib:/work/target/lib artemis-native-builder bash
 

--- a/src/main/docker/Dockerfile-centos.aarch64
+++ b/src/main/docker/Dockerfile-centos.aarch64
@@ -1,0 +1,36 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# ActiveMQ Artemis
+
+FROM arm64v8/centos:8 as builder-env
+
+LABEL maintainer="Apache ActiveMQ Team"
+
+RUN yum groupinstall -y "Development Tools" && \
+	yum install -y vim cmake libaio libaio-devel java-1.8.0-openjdk-devel && yum clean all
+
+FROM builder-env as builder
+
+ADD . /work
+
+VOLUME ["/work/target/lib"]
+VOLUME ["/root/.m2/repository"]
+
+WORKDIR /work
+
+CMD [ "sh", "-c", "/work/scripts/compile-native.sh"]


### PR DESCRIPTION
It uses QEMU for aarch64 emulation

The outcome is:

```txt
$ file target/lib/linux-aarch64/libartemis-native-64.so                                                                                   
target/lib/linux-aarch64/libartemis-native-64.so: ELF 64-bit LSB shared object, ARM aarch64, version 1 (SYSV), dynamically linked, BuildID[sha1]=f5bbbf224a2bf09575bbea265922d54829e956ca, not stripped

$ file target/lib/linux-amd64/libartemis-native-64.so                                                                                     
target/lib/linux-amd64/libartemis-native-64.so: ELF 64-bit LSB shared object, x86-64, version 1 (SYSV), dynamically linked, BuildID[sha1]=da4a34dacca9be3fa978683d1a5c41076b820503, not stripped

$ file target/lib/linux-i686/libartemis-native-32.so                                                                                      
target/lib/linux-i686/libartemis-native-32.so: ELF 32-bit LSB shared object, Intel 80386, version 1 (SYSV), dynamically linked, BuildID[sha1]=076e3a29dd152ac2f0c268628ca8b7913a055f99, not stripped
```