### PR TITLE
reorder build steps and make slf4j be provided

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
+            <scope>provided</scope>
             <!-- License: MIT -->
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
                         <executions>
                             <execution>
                                 <id>build</id>
-                                <phase>generate-sources</phase>
+                                <phase>process-sources</phase>
                                 <goals>
                                     <goal>exec</goal>
                                 </goals>
@@ -158,7 +158,7 @@
                         <executions>
                             <execution>
                                 <id>build</id>
-                                <phase>generate-sources</phase>
+                                <phase>process-sources</phase>
                                 <goals>
                                     <goal>exec</goal>
                                 </goals>
@@ -182,7 +182,7 @@
                         <executions>
                             <execution>
                                 <id>build</id>
-                                <phase>generate-sources</phase>
+                                <phase>process-sources</phase>
                                 <goals>
                                     <goal>exec</goal>
                                 </goals>
@@ -259,16 +259,6 @@
     <build>
         <pluginManagement>
             <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <configuration>
-                        <compilerArgs>
-                            <arg>-h</arg>
-                            <arg>./src/main/c</arg>
-                        </compilerArgs>
-                    </configuration>
-                </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
@@ -410,6 +400,29 @@
                 <artifactId>maven-help-plugin</artifactId>
                 <version>2.2</version>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <!-- Running compilation at generate-sources stage instead, to also generate the .h file
+                             ahead of running the cmake build at process-sources phase, in the profiles above -->
+                        <phase>generate-sources</phase>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                        <configuration>
+                            <compilerArgs>
+                                <arg>-h</arg>
+                                <arg>./src/main/c</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -84,30 +84,31 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>provided</scope>
+            <!-- License: MIT -->
+        </dependency>
+
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
             <!-- License: EPL 1.0 -->
         </dependency>
-       <dependency>
-          <groupId>org.jacoco</groupId>
-          <artifactId>org.jacoco.ant</artifactId>
-          <version>${version.org.jacoco}</version>
-          <scope>test</scope>
-       </dependency>
-       <dependency>
-          <groupId>org.jacoco</groupId>
-          <artifactId>org.jacoco.core</artifactId>
-          <version>${version.org.jacoco}</version>
-           <scope>test</scope>
-       </dependency>
         <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.version}</version>
-            <scope>provided</scope>
-            <!-- License: MIT -->
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.ant</artifactId>
+            <version>${version.org.jacoco}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.core</artifactId>
+            <version>${version.org.jacoco}</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>

--- a/src/main/java/org/apache/activemq/artemis/nativo/jlibaio/LibaioContext.java
+++ b/src/main/java/org/apache/activemq/artemis/nativo/jlibaio/LibaioContext.java
@@ -44,9 +44,11 @@ import org.slf4j.LoggerFactory;
  * <a href="https://ext4.wiki.kernel.org/index.php/Clarifying_Direct_IO's_Semantics">Interesting reading for this.</a>
  */
 public class LibaioContext<Callback extends SubmitInfo> implements Closeable {
-   /* Notice: After making changes to the native interface, you have to use mvn install at least once to generate the include file.
+   /* Notice: After making changes to the native interface, mvn 'generate-sources' must occur at least once to generate the updated include file.
       This is because the maven compiler plugin is the one generating org_apache_activemq_artemis_native_jlibaio_LibaioContext.h
-      So that file needs to be updated before Cmake comes along to compile the module. */
+      So that file needs to be updated before Cmake comes along to compile the module.
+      This normally happens as needed in the regular mvn build, so if you use e.g 'mvn clean install -Ppodman' then no extra step is needed,
+      specific attention is only required if you e.g run the build scripts directly yourself. */
 
    private static final Logger logger = LoggerFactory.getLogger(LibaioContext.class);
 


### PR DESCRIPTION
Reorders the build steps so that the javac -h [equivalent] run generates the header file in generate-sources, and bump the cmake run out to process-sources after that to ensure it sees the updated header. Makes slf4j be provided as the broker will supply an appropriate version. Makes some indentation consistent in the pom.